### PR TITLE
Control page routing by login status

### DIFF
--- a/src/components/CreateReport.vue
+++ b/src/components/CreateReport.vue
@@ -41,6 +41,7 @@ import firebase from '../firebase/firestore'
 export default {
   data() {
     return {
+      email: null,
       date: null,
       dairy_report: null,
       memo: null,
@@ -51,11 +52,26 @@ export default {
     }
   },
 
+  created: function() {
+    const self = this
+    firebase.auth().onAuthStateChanged(function(user) {
+      if (user) {
+        self.email = user.email
+      } else {
+        self.$router.push('/login')
+      }
+    })
+  },
+
   computed: {
     messageClass() {
       return {
         'md-invalid': this.hasMessages
       }
+    },
+
+    isAuthenticated() {
+      return this.email !== null
     }
   },
 
@@ -74,6 +90,7 @@ export default {
 
       // 保存用JSONデータを作成
       const saveData = {
+        email: this.email,
         date: this.date,
         dairy_report: this.dairy_report,
         memo: this.memo,

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,24 +1,52 @@
 <template>
   <div class="home">
-    <h1>Dairy Report management App</h1>
-    <h2>Let's write Dairy Report!</h2>
-    <div class="sign-up-button">
-      <md-button class="md-raised md-primary">Sign Up</md-button>
-    </div>
+    <h3 v-if="isAuthenticated">Welcome to Dairy Report management App</h3>
+    <div v-else>
+      <h1>Dairy Report management App</h1>
+      <h2>Let's write Dairy Report!</h2>
+      <div class="sign-up-button">
+        <md-button class="md-raised md-primary">Sign Up</md-button>
+      </div>
 
-    <div class="write-rearon-area">
-      <div class="write-reason-text-area">
-        <h3>Good things to write</h3>
-        <li>You can keep a daily record so you can always look back.</li>
-        <li>You can make time to think about the day.</li>
-        <li>And you can grow.</li>
-        <h4>As a result you can make your dreams come true.</h4>
+      <div class="write-rearon-area">
+        <div class="write-reason-text-area">
+          <h3>Good things to write</h3>
+          <li>You can keep a daily record so you can always look back.</li>
+          <li>You can make time to think about the day.</li>
+          <li>And you can grow.</li>
+          <h4>As a result you can make your dreams come true.</h4>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
-<script></script>
+<script>
+import firebase from '../firebase/firestore'
+
+export default {
+  data() {
+    return {
+      email: null
+    }
+  },
+
+  computed: {
+    isAuthenticated() {
+      return this.email !== null
+    }
+  },
+
+  created: function() {
+    const self = this
+    firebase.auth().onAuthStateChanged(function(user) {
+      if (user) {
+        self.email = user.email
+      }
+    })
+  }
+}
+</script>
 
 <style scoped>
 h1 {
@@ -27,6 +55,10 @@ h1 {
 
 h2 {
   text-align: center;
+}
+
+h3 {
+  margin-left: 60px;
 }
 
 .sign-up-button {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -38,8 +38,8 @@ export default {
         .auth()
         .signInWithEmailAndPassword(this.email, this.password)
         .then(function() {
-          // 正常にsignupできた時の処理
-          self.$router.push('/')
+          // 正常にloginできた時の処理
+          window.location.href = '/'
         })
         .catch(function() {
           // エラー発生時の処理

--- a/src/components/ReportList.vue
+++ b/src/components/ReportList.vue
@@ -28,22 +28,28 @@ export default {
   },
 
   created: function() {
-    const self = this
-    firebase
-      .firestore()
-      .collection('report')
-      .get()
-      .then(snapShot => {
-        snapShot.forEach(doc => {
-          self.reports.push({
-            dairy_report: doc.data().dairy_report,
-            date: doc.data().date.toDate(),
-            memo: doc.data().memo,
-            literature_url: doc.data().literature_url,
-            report_id: doc.id
+    this.getReport()
+  },
+
+  methods: {
+    getReport() {
+      const self = this
+      firebase
+        .firestore()
+        .collection('report')
+        .get()
+        .then(snapShot => {
+          snapShot.forEach(doc => {
+            self.reports.push({
+              dairy_report: doc.data().dairy_report,
+              date: doc.data().date.toDate(),
+              memo: doc.data().memo,
+              literature_url: doc.data().literature_url,
+              report_id: doc.id
+            })
           })
         })
-      })
+    }
   }
 }
 </script>

--- a/src/components/SignOut.vue
+++ b/src/components/SignOut.vue
@@ -7,13 +7,12 @@ import firebase from '../firebase/firestore'
 
 export default {
   created: function() {
-    const self = this
     firebase
       .auth()
       .signOut()
       .then(function() {
         // 正常にsignoutできた時の処理
-        self.$router.push('/login')
+        window.location.href = '/login'
       })
   }
 }

--- a/src/components/global/Header.vue
+++ b/src/components/global/Header.vue
@@ -2,12 +2,66 @@
   <div>
     <md-tabs md-sync-route class="md-primary">
       <md-tab id="tab-home" md-label="Home" to="/" exact></md-tab>
-      <md-tab id="tab-post" md-label="Create Report" to="/create"></md-tab>
-      <md-tab id="tab-list" md-label="Report List" to="/list"></md-tab>
-      <md-tab id="tab-settings" md-label="settings"></md-tab>
-      <md-tab id="tab-signup" md-label="Sign Up" to="/signup"></md-tab>
-      <md-tab id="tab-login" md-label="Login" to="/login"></md-tab>
-      <md-tab id="tab-signout" md-label="Signout" to="/signout"></md-tab>
+      <md-tab
+        v-if="isAuthenticated"
+        id="tab-post"
+        md-label="Create Report"
+        to="/create"
+      ></md-tab>
+      <md-tab
+        v-if="isAuthenticated"
+        id="tab-list"
+        md-label="Report List"
+        to="/list"
+      ></md-tab>
+      <md-tab
+        v-if="isAuthenticated"
+        id="tab-settings"
+        md-label="settings"
+      ></md-tab>
+      <div v-else>
+        <md-tab id="tab-signup" md-label="Sign Up" to="/signup"></md-tab>
+        <md-tab id="tab-login" md-label="Login" to="/login"></md-tab>
+      </div>
+      <md-tab
+        v-if="isAuthenticated"
+        id="tab-signout"
+        md-label="Signout"
+        to="/signout"
+      ></md-tab>
     </md-tabs>
   </div>
 </template>
+
+<script>
+import firebase from '../../firebase/firestore'
+
+export default {
+  data() {
+    return {
+      email: null
+    }
+  },
+
+  computed: {
+    isAuthenticated() {
+      return this.email !== null
+    }
+  },
+
+  created: function() {
+    this.getUserEmail()
+  },
+
+  methods: {
+    getUserEmail() {
+      const self = this
+      firebase.auth().onAuthStateChanged(function(user) {
+        if (user) {
+          self.email = user.email
+        }
+      })
+    }
+  }
+}
+</script>


### PR DESCRIPTION
ログイン状態によってルーティング処理等を設定しました。
今回行ったこと
・ログイン状態によってヘッダーを変える
・ログイン状態でしか日報作成ページに移動できないようにする
・日報作成の際にユーザーのEmailを渡すようにする（のちにユーザーの判別に使用）
・ログインとサインアウトの際にリロードするようにする
・リストページのレポートの受け取る処理をメソッドとして切る離す
・Homeページの画面表示をログイン時とログイン時ではないときで変える

やってないこと
・リストページの修正（変更が多くなりそうなので他のブランチで行います）